### PR TITLE
fix ccache directory

### DIFF
--- a/packpack
+++ b/packpack
@@ -116,7 +116,7 @@ docker run \
         --rm=true \
         --entrypoint=/build/userwrapper.sh \
         -e CCACHE_DIR=/ccache \
-        --volume "${HOME}/.cache:/ccache" \
+        --volume "${HOME}/.ccache:/ccache" \
         ${DOCKER_REPO}:${DOCKER_IMAGE} \
         make -f /pack/Makefile -C /source BUILDDIR=/build -j $@
 


### PR DESCRIPTION
Use `~/.ccache`, the default ccache cache directory, and not `~/.cache`, which is the default user cache directory (e.g. `XDG_CACHE_HOME`).

Additionally, wouldn't it be better to use a custom cache directory, and set `XDG_CACHE_HOME` so other tools (pip, snapcraft, ...) caches are persistent too? Something along those lines:

```diff
diff --git c/packpack w/packpack
index 9c6a2ee..3a7fa24 100755
--- c/packpack
+++ w/packpack
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 # PackPack version
 PACKVERSION=1.0.0
 
@@ -99,14 +101,17 @@ env | grep -E "PRODUCT|VERSION|RELEASE|TARBALL_|CHANGELOG_" > ${BUILDDIR}/env
 #
 # Fix security context for selinux
 #
-
 chcon -Rt svirt_sandbox_file_t ${PACKDIR} ${SOURCEDIR} ${BUILDDIR} \
     1> /dev/null 2> /dev/null || :
 
+# Setup cache dir.
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/packpack"
+mkdir -p "$CACHE_DIR"
+
 #
 # Start Docker
 #
-set -ex
+set -x
 docker run \
         --volume "${PACKDIR}:/pack:ro" \
         --volume "${SOURCEDIR}:/source:ro" \
@@ -115,8 +120,9 @@ docker run \
         --workdir /source \
         --rm=true \
         --entrypoint=/build/userwrapper.sh \
-        -e CCACHE_DIR=/ccache \
-        --volume "${HOME}/.cache:/ccache" \
+        -e XDG_CACHE_HOME=/cache \
+        -e CCACHE_DIR=/cache/ccache \
+        --volume "${CACHE_DIR}:/cache" \
         ${DOCKER_REPO}:${DOCKER_IMAGE} \
         make -f /pack/Makefile -C /source BUILDDIR=/build -j $@
```