### PR TITLE
Quiet tarball creation to avoid Travis 4MB log limit

### DIFF
--- a/pack/tarball.mk
+++ b/pack/tarball.mk
@@ -41,7 +41,7 @@ $(BUILDDIR)/$(TARBALL): $(BUILDDIR)/ls-lR.txt $(BUILDDIR)/VERSION
 		--transform="s,,$(PRODUCT)-$(VERSION)/,S" \
 		--owner=root --group=root \
 		-T $< --show-transformed \
-		-cavPf $@ $(BUILDDIR)/VERSION $(TARBALL_EXTRA_FILES)
+		-caPf $@ $(BUILDDIR)/VERSION $(TARBALL_EXTRA_FILES)
 	@echo "------------------------------------------------------------------"
 	@echo "Tarball is ready"
 	@echo "-------------------------------------------------------------------"


### PR DESCRIPTION
The tarring of the sources is currently very verbose for large projects, greatly eating into the 4MB limit on travis. This disables verbose on the tarball generation.