### PR TITLE
Fix upgrade of cmake in precise

### DIFF
--- a/docker/ubuntu-precise/Dockerfile
+++ b/docker/ubuntu-precise/Dockerfile
@@ -6,7 +6,7 @@ ADD preferences /etc/apt/preferences
 RUN apt-get update && apt-get install -y --force-yes \
     build-essential gdb git ccache \
     devscripts debhelper fakeroot cdbs equivs rpm alien \
-    sudo software-properties-common
+    sudo software-properties-common python-software-properties
 
 RUN echo '%adm ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"


### PR DESCRIPTION
Turns out in precise apt-add-repository is in a different package, add that package.

Followup to #8 

Needs docker rebuild.