### PR TITLE
Manually install latest version of ccache

### DIFF
--- a/docker/ubuntu-precise/Dockerfile
+++ b/docker/ubuntu-precise/Dockerfile
@@ -22,6 +22,8 @@ RUN pip install msgpack-python
 RUN apt-get update && apt-get install -t precise-backports -y luajit \
     lua5.1 liblua5.1-dev lua5.2 liblua5.2-dev dh-lua
 RUN curl -L https://packagecloud.io/tarantool/1_6/gpgkey | sudo apt-key add -
+RUN curl -s -O archive.ubuntu.com/ubuntu/pool/main/c/ccache/ccache_3.3.3-1_amd64.deb \
+    && dpkg -i ccache_3.3.3-1_amd64.deb && rm ccache_3.3.3-1_amd64.deb
 RUN apt-get update && apt-get install -y apt-transport-https
 ADD tarantool_1_6.list /etc/apt/sources.list.d/
 RUN apt-get update

--- a/docker/ubuntu-trusty/Dockerfile
+++ b/docker/ubuntu-trusty/Dockerfile
@@ -20,6 +20,8 @@ RUN apt-get update && apt-get install -y \
 RUN apt-get update && apt-get install -y luajit \
     lua5.1 liblua5.1-dev lua5.2 liblua5.2-dev dh-lua
 RUN curl -L https://packagecloud.io/tarantool/1_6/gpgkey | sudo apt-key add -
+RUN curl -s -O archive.ubuntu.com/ubuntu/pool/main/c/ccache/ccache_3.3.3-1_amd64.deb \
+    && dpkg -i ccache_3.3.3-1_amd64.deb && rm ccache_3.3.3-1_amd64.deb
 RUN apt-get update && apt-get install -y apt-transport-https
 ADD tarantool_1_6.list /etc/apt/sources.list.d/
 RUN apt-get update

--- a/docker/ubuntu-wily/Dockerfile
+++ b/docker/ubuntu-wily/Dockerfile
@@ -20,6 +20,8 @@ RUN apt-get update && apt-get install -y \
 RUN apt-get update && apt-get install -y luajit \
     lua5.1 liblua5.1-dev lua5.2 liblua5.2-dev lua5.3 liblua5.3-dev dh-lua
 RUN curl -L https://packagecloud.io/tarantool/1_6/gpgkey | sudo apt-key add -
+RUN curl -s -O archive.ubuntu.com/ubuntu/pool/main/c/ccache/ccache_3.3.3-1_amd64.deb \
+    && dpkg -i ccache_3.3.3-1_amd64.deb && rm ccache_3.3.3-1_amd64.deb
 RUN apt-get update && apt-get install -y apt-transport-https
 ADD tarantool_1_6.list /etc/apt/sources.list.d/
 RUN apt-get update

--- a/docker/ubuntu-xenial/Dockerfile
+++ b/docker/ubuntu-xenial/Dockerfile
@@ -20,6 +20,8 @@ RUN apt-get update && apt-get install -y \
 RUN apt-get update && apt-get install -y luajit \
     lua5.1 liblua5.1-dev lua5.2 liblua5.2-dev lua5.3 liblua5.3-dev dh-lua
 RUN curl -L https://packagecloud.io/tarantool/1_6/gpgkey | sudo apt-key add -
+RUN curl -s -O archive.ubuntu.com/ubuntu/pool/main/c/ccache/ccache_3.3.3-1_amd64.deb \
+    && dpkg -i ccache_3.3.3-1_amd64.deb && rm ccache_3.3.3-1_amd64.deb
 RUN apt-get update && apt-get install -y apt-transport-https
 ADD tarantool_1_6.list /etc/apt/sources.list.d/
 RUN apt-get update

--- a/docker/ubuntu-yakkety/Dockerfile
+++ b/docker/ubuntu-yakkety/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update && apt-get install -y \
 RUN apt-get update && apt-get install -y luajit \
     lua5.1 liblua5.1-dev lua5.2 liblua5.2-dev lua5.3 liblua5.3-dev dh-lua
 RUN curl -L https://packagecloud.io/tarantool/1_6/gpgkey | sudo apt-key add -
+RUN curl -s -O archive.ubuntu.com/ubuntu/pool/main/c/ccache/ccache_3.3.3-1_amd64.deb \
+    && dpkg -i ccache_3.3.3-1_amd64.deb && rm ccache_3.3.3-1_amd64.deb
 RUN apt-get update && apt-get install -y apt-transport-https
 ADD tarantool_1_6.list /etc/apt/sources.list.d/
 RUN apt-get update


### PR DESCRIPTION
Older versions of ccache have some odd bugs. For example, see https://github.com/ros-infrastructure/buildfarm_deployment/issues/113

ccache is very simple in terms of dependencies and can install/run on any ubuntu version.

This downloads and installs the latest version from ubuntu's dev tree.