### PR TITLE
Preserve ccache dir in debuild, also add ccache to path in build

### DIFF
--- a/pack/deb.mk
+++ b/pack/deb.mk
@@ -62,7 +62,8 @@ $(BUILDDIR)/$(DPKG_CHANGES): $(BUILDDIR)/$(PRODUCT)-$(VERSION)/debian/ \
 	@echo "-------------------------------------------------------------------"
 	rm -rf $(BUILDDIR)/tarball
 	cd $(BUILDDIR)/$(PRODUCT)-$(VERSION) && \
-		debuild -Z$(TARBALL_COMPRESSOR) -uc -us $(SMPFLAGS)
+		debuild -Z$(TARBALL_COMPRESSOR) -uc -us $(SMPFLAGS) \
+		--preserve-envvar=CCACHE_DIR --prepend-path=/usr/lib/ccache
 	rm -rf $(BUILDDIR)/$(PRODUCT)-$(VERSION)/
 	@echo "------------------------------------------------------------------"
 	@echo "Debian packages are ready"


### PR DESCRIPTION
Fixes #19 

This fixes the permission denied problems due to ccache trying to write to $HOME because the variable is lost.