### PR TITLE
WIP DONTMERGE: Quiet build some more, only show error output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
 script:
  - git submodule update --init --recursive
  - git describe --long
- - ./packpack
+ - travis_wait ./packpack
 
 deploy:
   # Deploy packages to PackageCloud

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ script:
  - git submodule update --init --recursive
  - git describe --long
  - git clone https://github.com/packpack/packpack.git packpack
- - packpack/packpack
+ - travis_wait 50 packpack/packpack
 
 deploy:
   # Deploy packages to PackageCloud

--- a/pack/deb.mk
+++ b/pack/deb.mk
@@ -63,7 +63,7 @@ $(BUILDDIR)/$(DPKG_CHANGES): $(BUILDDIR)/$(PRODUCT)-$(VERSION)/debian/ \
 	rm -rf $(BUILDDIR)/tarball
 	cd $(BUILDDIR)/$(PRODUCT)-$(VERSION) && \
 		debuild --preserve-envvar CCACHE_DIR --prepend-path=/usr/lib/ccache \
-		-Z$(TARBALL_COMPRESSOR) -uc -us $(SMPFLAGS)
+		-Z$(TARBALL_COMPRESSOR) -uc -us $(SMPFLAGS) 2>&1 >>$(BUILDDIR)/build.log | tee --append $(BUILDDIR)/build.log
 	rm -rf $(BUILDDIR)/$(PRODUCT)-$(VERSION)/
 	@echo "------------------------------------------------------------------"
 	@echo "Debian packages are ready"

--- a/pack/rpm.mk
+++ b/pack/rpm.mk
@@ -67,7 +67,7 @@ package: $(BUILDDIR)/$(RPMSRC)
 		--define '_srcrpmdir $(BUILDDIR)' \
 		--define '_builddir $(BUILDDIR)' \
 		--define '_smp_mflags $(SMPFLAGS)' \
-		--rebuild --with backtrace $< 2>&1 | tee $(BUILDDIR)/build.log
+		--rebuild --with backtrace $< 2>&1 >>$(BUILDDIR)/build.log | tee --append $(BUILDDIR)/build.log
 	mv -f $(BUILDDIR)/RPMS/*/*.rpm $(BUILDDIR)
 	rm -rf $(BUILDDIR)/RPMS/ $(BUILDDIR)/BUILDROOT
 	@echo "------------------------------------------------------------------"


### PR DESCRIPTION
Stole this lovely little trick from http://unix.stackexchange.com/a/80004/200255

Also, made debian produce a build log as well.

Things we lose:
- Build progress (now we only get errors)
- *perfect* ordering of output (stderr can get mixed into the stdout buffer a bit with this method) 

This is of course to further deal with the 4MB log limit of Travis.