### PR TITLE
Use nproc to detect number of processors if none specified

### DIFF
--- a/pack/config.mk
+++ b/pack/config.mk
@@ -78,4 +78,4 @@ ifneq ($(TRAVIS),)
 # Travis instances are limited to "2 cpus, bursted"
 SMPFLAGS ?= -j2
 endif
-SMPFLAGS ?= -j16
+SMPFLAGS ?= -j$(shell nproc)


### PR DESCRIPTION
Use the nproc shell command to detect number of processors if not specified.