### PR TITLE
Pass through any CCACHE_ and SMPFLAGS environment variables into docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ see an example in [tarantool/tarantool](Tarantool GitHub) repo.
 * `CHANGELOG_NAME`, `CHANGELOG_EMAIL`, `CHANGELOG_TEXT` - information
    used to bump version in changelog files.
 * `DOCKER_REPO` - a Docker repository to use (default is `packpack/packpack`).
+* `CCACHE*` - Config variables for ccache, such as CCACHE_DISABLE
 
 See the full list of available options and detailed configuration guide in
 [pack/config.mk](pack/config.mk) configuration file.

--- a/packpack
+++ b/packpack
@@ -94,7 +94,7 @@ chmod a+x ${BUILDDIR}/userwrapper.sh
 #
 # Save defined configuration variables to ./env file
 #
-env | grep -E "TRAVIS|PRODUCT|VERSION|RELEASE|TARBALL_|CHANGELOG_" \
+env | grep -E "TRAVIS|PRODUCT|VERSION|RELEASE|TARBALL_|CHANGELOG_|CCACHE_" \
     > ${BUILDDIR}/env
 
 #

--- a/packpack
+++ b/packpack
@@ -94,7 +94,7 @@ chmod a+x ${BUILDDIR}/userwrapper.sh
 #
 # Save defined configuration variables to ./env file
 #
-env | grep -E "TRAVIS|PRODUCT|VERSION|RELEASE|TARBALL_|CHANGELOG_|CCACHE_" \
+env | grep -E "TRAVIS|PRODUCT|VERSION|RELEASE|TARBALL_|CHANGELOG_|CCACHE_|SMPFLAGS" \
     > ${BUILDDIR}/env
 
 #


### PR DESCRIPTION
Should someone want to configure or disable ccache, this passes all CCACHE variables into the docker.

Most useful for CCACHE_DISABLE