### PR TITLE
Re-add no-install-recommends to dependency install

### DIFF
--- a/pack/deb.mk
+++ b/pack/deb.mk
@@ -54,7 +54,7 @@ $(BUILDDIR)/$(DPKG_CHANGES): $(BUILDDIR)/$(PRODUCT)-$(VERSION)/debian/ \
 	# sudo apt-get clean
 	# sudo rm -rf /var/lib/apt/lists/*
 	sudo apt-get update > /dev/null
-	cd $(BUILDDIR)/$(PRODUCT)-$(VERSION) && sudo mk-build-deps -i --tool "apt-get -y" || :
+	cd $(BUILDDIR)/$(PRODUCT)-$(VERSION) && sudo mk-build-deps -i --tool "apt-get --no-install-recommends -y" || :
 	cd $(BUILDDIR)/$(PRODUCT)-$(VERSION) && sudo rm -f *build-deps_*.deb
 	@echo
 	@echo "-------------------------------------------------------------------"


### PR DESCRIPTION
The original docs of ``mk-build-deps`` say

```
       -t, --tool
           When installing the generated package use the specified tool.  (default: apt-get --no-install-recommends)
```

The ``-y`` was clearly added so the install would be automated however we lost the recommends part. This re-adds it.