### PR TITLE
Pull container before run in case of update

### DIFF
--- a/packpack
+++ b/packpack
@@ -113,6 +113,7 @@ chcon -Rt svirt_sandbox_file_t ${PACKDIR} ${SOURCEDIR} ${BUILDDIR} \
 # Start Docker
 #
 set -ex
+docker pull ${DOCKER_REPO}:${DOCKER_IMAGE}
 docker run \
         --volume "${PACKDIR}:/pack:ro" \
         --volume "${SOURCEDIR}:/source:ro" \


### PR DESCRIPTION
When running on a bare-metal system instead of a travis instance or a VM, you may have pulled down a container before.

If that's the case, docker run will use the local copy, even if a more up-to-date version is available.

Add a docker pull command to cause an update.