### PR TITLE
Allocate a tty so that Ctrl-C works

### DIFF
--- a/packpack
+++ b/packpack
@@ -119,7 +119,7 @@ docker run \
         --volume "${BUILDDIR}:/build" \
         --env-file ${BUILDDIR}/env \
         --workdir /source \
-        --rm=true \
+        --rm=true --tty=true \
         --entrypoint=/build/userwrapper.sh \
         -e XDG_CACHE_HOME=/cache \
         -e CCACHE_DIR=/cache/ccache \


### PR DESCRIPTION
Right now, on a local run, Ctrl-C is completely ignored.

Docker needs a pseudo-tty allocated so that we can kill the build.