### PR TITLE
add support for %autosetup rpm macro

### DIFF
--- a/pack/rpm.mk
+++ b/pack/rpm.mk
@@ -23,11 +23,13 @@ $(BUILDDIR)/$(RPMSPEC): $(RPMSPECIN)
 		-e 's/Release:\([ ]*\).*/Release: $(RELEASE)%{dist}/' \
 		-e 's/Source0:\([ ]*\).*/Source0: $(TARBALL)/' \
 		-e 's/%setup .*/%setup -q -n $(PRODUCT)-$(VERSION)/' \
+		-e 's/%autosetup -n .*/%autosetup -n $(PRODUCT)-$(VERSION)/' \
 		-i $@.tmp
 	grep -F "Version: $(VERSION)" $@.tmp && \
 		grep -F "Release: $(RELEASE)" $@.tmp && \
 		grep -F "Source0: $(TARBALL)" $@.tmp && \
-		grep -F "%setup -q -n $(PRODUCT)-$(VERSION)" $@.tmp || \
+		(grep -F "%setup -q -n $(PRODUCT)-$(VERSION)" $@.tmp || \
+		grep -F "%autosetup" $@.tmp) || \
 		(echo "Failed to patch RPM spec" && exit 1)
 	@ mv -f $@.tmp $@
 	@echo


### PR DESCRIPTION
Fixes #54 
This PR allows the use of the %autosetup macro as documented in the Fedora packaging guidelines.

It will work under the following scenarios:

**a single `%autosetup` is found in %prep**
%autosetup by its definition figures out the name of the source file so using macro w/o any parameters should be expected. In this case, this part of the spec file is left w/o changes. e.g. no patching needed

**a single `%autosetup -n xxxxxx` is found in %prep**
%autosetup is backwards compatible with the `-n` parameter so if it was specified, patch that line in the specfile with $(PRODUCT)-$(VERSION)

**a single `%autosetup` macro and one or more `%autosetup -a x` macros are found in the spec file**
Such is the case if the project being used has git submodules. Each submodule gets identified as another SourceX line, followed by `%autosetup -a X` in %prep. In this case, only the first call to %autosetup is evaluated according the to conditions previously stated.
