### PR TITLE
config sed to replace only the first occurance of %autosetup

### DIFF
--- a/pack/rpm.mk
+++ b/pack/rpm.mk
@@ -24,7 +24,7 @@ $(BUILDDIR)/$(RPMSPEC): $(RPMSPECIN)
 		-e 's/Release:\([ ]*\).*/Release: $(RELEASE)%{dist}/' \
 		-e 's/Source0:\([ ]*\).*/Source0: $(TARBALL)/' \
 		-e 's/%setup.*/%setup -q -n $(PRODUCT)-$(VERSION)/' \
-		-e 's/%autosetup.*/%autosetup -n $(PRODUCT)-$(VERSION)/' \
+		-e '0,/%autosetup.*/ s/%autosetup.*/%autosetup -n $(PRODUCT)-$(VERSION)/' \
 		-i $@.tmp
 	grep -F "Version: $(VERSION)" $@.tmp && \
 		grep -F "Release: $(RELEASE)" $@.tmp && \


### PR DESCRIPTION
This pr represents one way to fix #59

This method requires gnu sed (e.g. might not work on *BSD)

I don't think this project requires *BSD compatibility. Please advise. 
If so, this pr can be made Posix compliant, but it is not nearly as pretty.

Awk could also be used instead of sed.
