### PR TITLE
auto insert packpack rpm changelog entry

### DIFF
--- a/pack/rpm.mk
+++ b/pack/rpm.mk
@@ -13,6 +13,8 @@ RPMDIST := $(shell rpm -E "%{dist}")
 PKGVERSION := $(VERSION)-$(RELEASE)$(RPMDIST)
 RPMSPEC := $(RPMNAME).spec
 RPMSRC := $(RPMNAME)-$(PKGVERSION).src.rpm
+THEDATE := $(shell date +"%a %b %d %Y")
+GITHASH := $(shell git rev-parse --short HEAD)
 
 $(BUILDDIR)/$(RPMSPEC): $(RPMSPECIN)
 	@echo "-------------------------------------------------------------------"
@@ -25,6 +27,7 @@ $(BUILDDIR)/$(RPMSPEC): $(RPMSPECIN)
 		-e 's/Source0:\([ ]*\).*/Source0: $(TARBALL)/' \
 		-e 's/%setup.*/%setup -q -n $(PRODUCT)-$(VERSION)/' \
 		-e '0,/%autosetup.*/ s/%autosetup.*/%autosetup -n $(PRODUCT)-$(VERSION)/' \
+                -e '/%changelog/a\* $(THEDATE) PackPack <build@tarantool.org> - $(VERSION)-$(RELEASE)\n\- packpack nightly rebuild git rev $(GITHASH)\n' \
 		-i $@.tmp
 	grep -F "Version: $(VERSION)" $@.tmp && \
 		grep -F "Release: $(RELEASE)" $@.tmp && \

--- a/pack/rpm.mk
+++ b/pack/rpm.mk
@@ -14,7 +14,6 @@ PKGVERSION := $(VERSION)-$(RELEASE)$(RPMDIST)
 RPMSPEC := $(RPMNAME).spec
 RPMSRC := $(RPMNAME)-$(PKGVERSION).src.rpm
 THEDATE := $(shell date +"%a %b %d %Y")
-GITHASH := $(shell git rev-parse --short HEAD)
 
 $(BUILDDIR)/$(RPMSPEC): $(RPMSPECIN)
 	@echo "-------------------------------------------------------------------"
@@ -27,7 +26,7 @@ $(BUILDDIR)/$(RPMSPEC): $(RPMSPECIN)
 		-e 's/Source0:\([ ]*\).*/Source0: $(TARBALL)/' \
 		-e 's/%setup.*/%setup -q -n $(PRODUCT)-$(VERSION)/' \
 		-e '0,/%autosetup.*/ s/%autosetup.*/%autosetup -n $(PRODUCT)-$(VERSION)/' \
-                -e '/%changelog/a\* $(THEDATE) PackPack <build@tarantool.org> - $(VERSION)-$(RELEASE)\n\- packpack rebuild git rev $(GITHASH)\n' \
+                -e '/%changelog/a\* $(THEDATE) $(CHANGELOG_NAME) <$(CHANGELOG_EMAIL)> - $(VERSION)-$(RELEASE)\n\- $(CHANGELOG_TEXT)\n' \
 		-i $@.tmp
 	grep -F "Version: $(VERSION)" $@.tmp && \
 		grep -F "Release: $(RELEASE)" $@.tmp && \

--- a/pack/rpm.mk
+++ b/pack/rpm.mk
@@ -27,7 +27,7 @@ $(BUILDDIR)/$(RPMSPEC): $(RPMSPECIN)
 		-e 's/Source0:\([ ]*\).*/Source0: $(TARBALL)/' \
 		-e 's/%setup.*/%setup -q -n $(PRODUCT)-$(VERSION)/' \
 		-e '0,/%autosetup.*/ s/%autosetup.*/%autosetup -n $(PRODUCT)-$(VERSION)/' \
-                -e '/%changelog/a\* $(THEDATE) PackPack <build@tarantool.org> - $(VERSION)-$(RELEASE)\n\- packpack nightly rebuild git rev $(GITHASH)\n' \
+                -e '/%changelog/a\* $(THEDATE) PackPack <build@tarantool.org> - $(VERSION)-$(RELEASE)\n\- packpack rebuild git rev $(GITHASH)\n' \
 		-i $@.tmp
 	grep -F "Version: $(VERSION)" $@.tmp && \
 		grep -F "Release: $(RELEASE)" $@.tmp && \


### PR DESCRIPTION
Inserts a changelog entry when packpack is run. For example:
```
%changelog
* Wed Mar 08 2017 PackPack <build@tarantool.org> - 1.30.2-50
- packpack nightly rebuild git rev e61a3fa
```

At the moment, the information you see is not changeable by the end user, but it could be if someone makes a case for it.

UPDATE: I've removed the word "nightly" from the changelog text