### PR TITLE
Allow to override some environment vars

### DIFF
--- a/pack/deb.mk
+++ b/pack/deb.mk
@@ -51,7 +51,7 @@ ifeq ("$(DEB_SOURCE_FORMAT)","3.0 (native)")
 endif
 	# Bump version in debian/changelog
 	cd $(BUILDDIR)/$(PRODUCT)-$(VERSION) && \
-		NAME=$(CHANGELOG_NAME) DEBEMAIL=$(CHANGELOG_EMAIL) \
+		NAME="$(CHANGELOG_NAME)" DEBEMAIL=$(CHANGELOG_EMAIL) \
 		dch -b -v "$(DEB_VERSION)-$(RELEASE)" "$(CHANGELOG_TEXT)"
 
 $(BUILDDIR)/$(DPKG_ORIG_TARBALL): $(BUILDDIR)/$(TARBALL)

--- a/packpack
+++ b/packpack
@@ -36,7 +36,7 @@ if [ -z "${DOCKER_IMAGE}" ]; then
         # Use ubuntu-xenial docker image if OS or DIST is invalid
         DOCKER_IMAGE=ubuntu-xenial
     fi
-    
+
     if [ "${ARCH}" != "x86_64" ]; then
         DOCKER_IMAGE="${DOCKER_IMAGE}-${ARCH}"
     fi
@@ -109,8 +109,11 @@ chmod a+x ${BUILDDIR}/userwrapper.sh
 #
 # Save defined configuration variables to ./env file
 #
+# First, we need to make sure that the env file is exists
+touch ${BUILDDIR}/env
+# Then, append environment variables
 env | grep -E "TRAVIS|PRODUCT|VERSION|RELEASE|TARBALL_|CHANGELOG_|CCACHE_|PACKAGECLOUD_|SMPFLAGS" \
-    > ${BUILDDIR}/env
+    >> ${BUILDDIR}/env
 
 #
 # Setup cache directory

--- a/packpack
+++ b/packpack
@@ -15,15 +15,6 @@ BUILDDIR=${BUILDDIR:-${SOURCEDIR}/build}
 # Docker repository to use
 DOCKER_REPO=${DOCKER_REPO:-packpack/packpack}
 
-# Docker image to use
-if [ -n "${OS}" ] && [ -n "${DIST}" ]; then
-    # Non-numeric dist, e.g. debian-sid, ubuntu-precise, etc.
-    DOCKER_IMAGE="${OS}-${DIST}"
-else
-    # Use ubuntu-xenial docker image if OS or DIST is invalid
-    DOCKER_IMAGE=ubuntu-xenial
-fi
-
 # Docker architecture
 if [ -z "${ARCH}" ]; then
     # Use uname -m instead of HOSTTYPE
@@ -36,8 +27,19 @@ if [ -z "${ARCH}" ]; then
     esac
 fi
 
-if [ "${ARCH}" != "x86_64" ]; then
-    DOCKER_IMAGE="${DOCKER_IMAGE}-${ARCH}"
+# Docker image to use
+if [ -z "${DOCKER_IMAGE}" ]; then
+    if [ -n "${OS}" ] && [ -n "${DIST}" ]; then
+        # Non-numeric dist, e.g. debian-sid, ubuntu-precise, etc.
+        DOCKER_IMAGE="${OS}-${DIST}"
+    else
+        # Use ubuntu-xenial docker image if OS or DIST is invalid
+        DOCKER_IMAGE=ubuntu-xenial
+    fi
+    
+    if [ "${ARCH}" != "x86_64" ]; then
+        DOCKER_IMAGE="${DOCKER_IMAGE}-${ARCH}"
+    fi
 fi
 
 version() {

--- a/packpack
+++ b/packpack
@@ -7,7 +7,7 @@ PACKVERSION=1.0.0
 PACKDIR=$(cd $(dirname $0) && pwd)/pack
 
 # Source directory
-SOURCEDIR=${PWD}
+SOURCEDIR=${SOURCEDIR:-$PWD}
 
 # Build directory
 BUILDDIR=${BUILDDIR:-${SOURCEDIR}/build}


### PR DESCRIPTION
Hello

This ability is pretty important to us.
For example we need to build our PHP package by using our Docker images:
```bash
${DOCKER_REPO}:centos7-ius55
${DOCKER_REPO}:centos7-ius56
${DOCKER_REPO}:centos7-ius70
${DOCKER_REPO}:centos7-ius71
```

This PR introduces ability to decide what image to use in each case. So in this case developer has to care about the architecture on their own.

Secondly, this PR provides opportunity to store in packagecloud RPMs like:

- <strong>`php55u-`</strong>phalcon-3.0.4-1<strong>`.ius`</strong>.el7.centos.x86_64.rpm (*Remi/IUS*)
- ...
- <strong>`php55w-`</strong>phalcon-3.0.4-1<strong>`.w6`</strong>.el7.centos.x86_64.rpm (*Webtatic*)
- ...

Thanks