### PR TITLE
remove quotes from CHANGELOG_NAME, CHANGELOG_EMAIL, and CHANGELOG_TEXT

### DIFF
--- a/pack/config.mk
+++ b/pack/config.mk
@@ -54,9 +54,9 @@ RELEASE ?= 1
 REVISION ?= $(shell git rev-parse HEAD)
 
 # Name, email and text for changelog entry
-CHANGELOG_NAME ?= "PackPack"
-CHANGELOG_EMAIL ?= "build@tarantool.org"
-CHANGELOG_TEXT ?= "Automated build"
+CHANGELOG_NAME ?= PackPack
+CHANGELOG_EMAIL ?= build@tarantool.org
+CHANGELOG_TEXT ?= Automated build
 
 # Extra arguments for tar
 TARBALL_EXTRA_ARGS ?=


### PR DESCRIPTION
As the title implies, this pr removes the quotes from the changelog variables. GNU Make does not use quotes for variable assignment like bash does and having the quotes there makes them part of the variable.

Testing this pr against an rpm build allows the rpm changelog to appear correctly:
```
%changelog
* Fri Mar 17 2017 PackPack <build@tarantool.org> - 1.30.2.0-1
- Automated build
```
Instead of:
```
%changelog
* Fri Mar 17 2017 "PackPack" <"build@tarantool.org"> - 1.30.2.0-1
- "Automated build"
```

I tested this against an ubuntu xenial build as well. This pr did not have any affect on the changelog contents, which is what we want. I am not as well versed in debian packaging so a second opinion would be helpful.
