### PR TITLE
rpm specfile with multiple "autosetup -n name" references

### DIFF
--- a/pack/rpm.mk
+++ b/pack/rpm.mk
@@ -25,6 +25,7 @@ $(BUILDDIR)/$(RPMSPEC): $(RPMSPECIN)
 		-e 's/Release:\([ ]*\).*/Release: $(RELEASE)%{dist}/' \
 		-e 's/Source0:\([ ]*\).*/Source0: $(TARBALL)/' \
 		-e 's/%setup.*/%setup -q -n $(PRODUCT)-$(VERSION)/' \
+                -re 's/(%autosetup.*)( -n \S*)(.*)/\1\3/' \
 		-e '0,/%autosetup.*/ s/%autosetup.*/%autosetup -n $(PRODUCT)-$(VERSION)/' \
                 -e '/%changelog/a\* $(THEDATE) $(CHANGELOG_NAME) <$(CHANGELOG_EMAIL)> - $(VERSION)-$(RELEASE)\n\- $(CHANGELOG_TEXT)\n' \
 		-i $@.tmp


### PR DESCRIPTION
This fixes a case where the rpm specfile references multiple sources, uses the autosetup macro, and the -n parameter is being used (because the tarball name does not match the package name).

To fix, this pr strips out the existing "-n name" portion from the macro before doing anything else.
This pr uses features only available with GNU sed e.g. doesn't work on *BSD.

NOTE: This change probably needs to be applied when using the legacy %setup macro as well when under the same conditions. I'm low on time and was not able to test that case.