### PR TITLE
Update installed RPMs before installing build dependencies in rpm.mk.

### DIFF
--- a/pack/rpm.mk
+++ b/pack/rpm.mk
@@ -63,6 +63,7 @@ package: $(BUILDDIR)/$(RPMSRC)
 	if [ -n "$(PACKAGECLOUD_USER)" ] && [ -n "$(PACKAGECLOUD_REPO)" ]; then \
 		curl -s https://packagecloud.io/install/repositories/$(PACKAGECLOUD_USER)/$(PACKAGECLOUD_REPO)/script.rpm.sh | sudo bash; \
 	fi
+	sudo dnf update -y || sudo yum update -y
 	sudo dnf builddep -y $< || sudo yum-builddep -y $<
 	@echo
 	@echo "-------------------------------------------------------------------"


### PR DESCRIPTION
In some edge cases latest versions of build dependencies may conflict
with outdated versions of installed packages. The only solution is to
update the corresponding conflicting packages first, but RPM specs do
not allow that.

As a workaround, do a full system update before installing build
dependencies. This increases build times considerably, so making this
behavior optional may be the next step.