### PR TITLE
Add dist to changelog

### DIFF
--- a/pack/config.mk
+++ b/pack/config.mk
@@ -70,6 +70,7 @@ ABBREV ?= $(shell echo $(DESCRIBE) | sed -n 's/^\([0-9\.]*\)-\([0-9]*\)-\([a-z0-
 CHANGELOG_NAME ?= PackPack
 CHANGELOG_EMAIL ?= build@tarantool.org
 CHANGELOG_TEXT ?= Automated build
+CHANGELOG_DIST ?= $(shell echo $$DIST)
 
 # Extra arguments for tar
 TARBALL_EXTRA_ARGS ?=

--- a/pack/config.mk
+++ b/pack/config.mk
@@ -70,7 +70,12 @@ ABBREV ?= $(shell echo $(DESCRIBE) | sed -n 's/^\([0-9\.]*\)-\([0-9]*\)-\([a-z0-
 CHANGELOG_NAME ?= PackPack
 CHANGELOG_EMAIL ?= build@tarantool.org
 CHANGELOG_TEXT ?= Automated build
-CHANGELOG_DIST ?= $(shell echo $$DIST)
+
+CHANGELOG_DIST ?= $(DIST)
+ifeq ($(CHANGELOG_DIST),)
+CHANGELOG_DIST := UNRELEASED
+endif
+
 
 # Extra arguments for tar
 TARBALL_EXTRA_ARGS ?=

--- a/pack/deb.mk
+++ b/pack/deb.mk
@@ -54,7 +54,7 @@ endif
 	# Bump version in debian/changelog
 	cd $(BUILDDIR)/$(PRODUCT)-$(VERSION) && \
 		NAME="$(CHANGELOG_NAME)" DEBEMAIL=$(CHANGELOG_EMAIL) \
-		dch -b -v "$(DEB_VERSION)-$(RELEASE)" "$(CHANGELOG_TEXT)"
+		dch -b -v "$(DEB_VERSION)-$(RELEASE)" --distribution="$(DIST)" "$(CHANGELOG_TEXT)"
 
 $(BUILDDIR)/$(DPKG_ORIG_TARBALL): $(BUILDDIR)/$(TARBALL)
 	# Create a symlink for orig.tar.gz

--- a/pack/deb.mk
+++ b/pack/deb.mk
@@ -54,7 +54,7 @@ endif
 	# Bump version in debian/changelog
 	cd $(BUILDDIR)/$(PRODUCT)-$(VERSION) && \
 		NAME="$(CHANGELOG_NAME)" DEBEMAIL=$(CHANGELOG_EMAIL) \
-		dch -b -v "$(DEB_VERSION)-$(RELEASE)" --distribution="$(DIST)" "$(CHANGELOG_TEXT)"
+		dch -b -v "$(DEB_VERSION)-$(RELEASE)" --distribution="$(CHANGELOG_DIST)" "$(CHANGELOG_TEXT)"
 
 $(BUILDDIR)/$(DPKG_ORIG_TARBALL): $(BUILDDIR)/$(TARBALL)
 	# Create a symlink for orig.tar.gz


### PR DESCRIPTION
So we are trying to use packpack to generate packages and then use those packages with mini-dinstall to make a ppa for our nightly builds.

Problem is that packpack doesn't set the distro field in the changelog, so it defaults to UNRELEASED which isn't very useful.

This PR adds a variable CHANGELOG_DIST and defaults it to $DIST and uses it on the dch command line to set the distro value.