### PR TITLE
Fix GH-82: allow only alpha-numeric characters for RPMNAME in rpm.mk.

### DIFF
--- a/pack/rpm.mk
+++ b/pack/rpm.mk
@@ -8,7 +8,7 @@ $(error Can't find RPM spec in rpm/ directory)
 endif
 $(info Using $(RPMSPECIN) file)
 
-RPMNAME := $(shell sed -n -e 's/Name:\([\ \t]*\)\(.*\)/\2/p' $(RPMSPECIN))
+RPMNAME := $(shell sed -n -e 's/Name:\([\ \t]*\)\([a-zA-Z0-9]*\).*/\2/p' $(RPMSPECIN))
 RPMDIST := $(shell rpm -E "%{dist}")
 PKGVERSION := $(VERSION)-$(RELEASE)$(RPMDIST)
 RPMSPEC := $(RPMNAME).spec


### PR DESCRIPTION
When generating RPMNAME from the 'Name:' tag in RPM Spec, keep only the
first sequence of alpha-numeric characters.