### PR TITLE
Fix GH-82: broken build with special characters in 'Name:' tag

### DIFF
--- a/pack/rpm.mk
+++ b/pack/rpm.mk
@@ -8,7 +8,14 @@ $(error Can't find RPM spec in rpm/ directory)
 endif
 $(info Using $(RPMSPECIN) file)
 
+RPMSPEC_AVAIL := $(shell command -v rpmspec 2> /dev/null)
+
+ifndef RPMSPEC_AVAIL
+RPMNAME := $(shell sed -n -e 's/Name:\([\ \t]*\)\(.*\)/\2/p' $(RPMSPECIN))
+else
 RPMNAME := $(shell rpmspec -P $(RPMSPECIN) | sed -n -e 's/Name:\([\ \t]*\)\(.*\)/\2/p')
+endif
+
 RPMDIST := $(shell rpm -E "%{dist}")
 PKGVERSION := $(VERSION)-$(RELEASE)$(RPMDIST)
 RPMSPEC := $(RPMNAME).spec

--- a/pack/rpm.mk
+++ b/pack/rpm.mk
@@ -8,7 +8,7 @@ $(error Can't find RPM spec in rpm/ directory)
 endif
 $(info Using $(RPMSPECIN) file)
 
-RPMNAME := $(shell sed -n -e 's/Name:\([\ \t]*\)\(.*\)/\2/p' $(RPMSPECIN))
+RPMNAME := $(shell rpmspec -P $(RPMSPECIN) | sed -n -e 's/Name:\([\ \t]*\)\(.*\)/\2/p')
 RPMDIST := $(shell rpm -E "%{dist}")
 PKGVERSION := $(VERSION)-$(RELEASE)$(RPMDIST)
 RPMSPEC := $(RPMNAME).spec


### PR DESCRIPTION
When generating RPMNAME from the 'Name:' tag in RPM Spec, expand RPM
macros to avoid breaking the build with 1) non-alphanumeric characters
in a Make variable and 2) inconsistencies between package names
generated by RPM tools and the ones being used by packpack.