### PR TITLE
Make prebuild targets phony.

### DIFF
--- a/pack/deb.mk
+++ b/pack/deb.mk
@@ -41,40 +41,37 @@ export DEBIAN_FRONTEND=noninteractive
 # Run prebuild scripts
 #
 ifeq ($(wildcard debian/$(PREBUILD)),)
-$(BUILDDIR)/$(PREBUILD):
+prebuild:
 	# empty
 else
-$(BUILDDIR)/$(PREBUILD): debian/$(PREBUILD)
+prebuild: debian/$(PREBUILD)
 	@echo "-------------------------------------------------------------------"
 	@echo "Running common $(PREBUILD) script"
 	@echo "-------------------------------------------------------------------"
-	@cp $< $@
 	$@
 	@echo
 endif
 
 ifeq ($(wildcard debian/$(PREBUILD_OS)),)
-$(BUILDDIR)/$(PREBUILD_OS):
+prebuild-$(OS):
 	# empty
 else
-$(BUILDDIR)/$(PREBUILD_OS): debian/$(PREBUILD_OS)
+prebuild-$(OS): debian/$(PREBUILD_OS)
 	@echo "-------------------------------------------------------------------"
 	@echo "Running $(PREBUILD_OS) script"
 	@echo "-------------------------------------------------------------------"
-	@cp $< $@
 	$@
 	@echo
 endif
 
 ifeq ($(wildcard debian/$(PREBUILD_OS_DIST)),)
-$(BUILDDIR)/$(PREBUILD_OS_DIST):
+prebuild-$(OS)-$(DIST):
 	# empty
 else
-$(BUILDDIR)/$(PREBUILD_OS_DIST): debian/$(PREBUILD_OS_DIST)
+prebuild-$(OS)-$(DIST): debian/$(PREBUILD_OS_DIST)
 	@echo "-------------------------------------------------------------------"
 	@echo "Running $(PREBUILD_OS_DIST) script"
 	@echo "-------------------------------------------------------------------"
-	@cp $< $@
 	$@
 	@echo
 endif
@@ -114,9 +111,9 @@ prepare: $(BUILDDIR)/$(PRODUCT)-$(VERSION)/debian \
 #
 $(BUILDDIR)/$(DPKG_CHANGES): $(BUILDDIR)/$(PRODUCT)-$(VERSION)/debian \
                              $(BUILDDIR)/$(DPKG_ORIG_TARBALL) \
-                             $(BUILDDIR)/$(PREBUILD) \
-                             $(BUILDDIR)/$(PREBUILD_OS) \
-                             $(BUILDDIR)/$(PREBUILD_OS_DIST)
+                             prebuild \
+                             prebuild-$(OS) \
+                             prebuild-$(OS)-$(DIST)
 	@echo "-------------------------------------------------------------------"
 	@echo "Installing dependencies"
 	@echo "-------------------------------------------------------------------"
@@ -159,11 +156,8 @@ clean::
 	rm -f $(BUILDDIR)/$(DPKG_ORIG_TARBALL)
 	rm -f $(BUILDDIR)/$(DPKG_DEBIAN_TARBALL)
 	rm -f $(BUILDDIR)/$(DPKG_DSC)
-	rm -f $(BUILDDIR)/$(PREBUILD)
-	rm -f $(BUILDDIR)/$(PREBUILD_OS)
-	rm -f $(BUILDDIR)/$(PREBUILD_OS_DIST)
 	rm -f $(BUILDDIR)/*.deb
 	rm -rf $(BUILDDIR)/$(PRODUCT)-$(VERSION)/
 
-.PHONY: clean
+.PHONY: clean prebuild prebuild-$(OS) prebuild-$(OS)-$(DIST)
 .PRECIOUS:: $(BUILDDIR)/$(PRODUCT)-$(VERSION)/

--- a/pack/rpm.mk
+++ b/pack/rpm.mk
@@ -23,41 +23,38 @@ THEDATE := $(shell date +"%a %b %d %Y")
 # Run prebuild scripts
 #
 ifeq ($(wildcard rpm/$(PREBUILD)),)
-$(BUILDDIR)/$(PREBUILD):
+prebuild:
 	# empty
 else
-$(BUILDDIR)/$(PREBUILD): rpm/$(PREBUILD)
+prebuild: rpm/$(PREBUILD)
 	@echo "-------------------------------------------------------------------"
 	@echo "Running common $(PREBUILD) script"
 	@echo "-------------------------------------------------------------------"
-	@cp $< $@
-	$@
+	$<
 	@echo
 endif
 
 ifeq ($(wildcard rpm/$(PREBUILD_OS)),)
-$(BUILDDIR)/$(PREBUILD_OS):
+prebuild-$(OS):
 	# empty
 else
-$(BUILDDIR)/$(PREBUILD_OS): rpm/$(PREBUILD_OS)
+prebuild-$(OS): rpm/$(PREBUILD_OS)
 	@echo "-------------------------------------------------------------------"
 	@echo "Running $(PREBUILD_OS) script"
 	@echo "-------------------------------------------------------------------"
-	@cp $< $@
-	$@
+	$<
 	@echo
 endif
 
 ifeq ($(wildcard rpm/$(PREBUILD_OS_DIST)),)
-$(BUILDDIR)/$(PREBUILD_OS_DIST):
+prebuild-$(OS)-$(DIST):
 	# empty
 else
-$(BUILDDIR)/$(PREBUILD_OS_DIST): rpm/$(PREBUILD_OS_DIST)
+prebuild-$(OS)-$(DIST): rpm/$(PREBUILD_OS_DIST)
 	@echo "-------------------------------------------------------------------"
 	@echo "Running $(PREBUILD_OS_DIST) script"
 	@echo "-------------------------------------------------------------------"
-	@cp $< $@
-	$@
+	$<
 	@echo
 endif
 
@@ -90,9 +87,9 @@ $(BUILDDIR)/$(RPMSPEC): $(RPMSPECIN)
 #
 $(BUILDDIR)/$(RPMSRC): $(BUILDDIR)/$(TARBALL) \
                        $(BUILDDIR)/$(RPMSPEC) \
-                       $(BUILDDIR)/$(PREBUILD) \
-                       $(BUILDDIR)/$(PREBUILD_OS) \
-                       $(BUILDDIR)/$(PREBUILD_OS_DIST)
+                       prebuild \
+                       prebuild-$(OS) \
+                       prebuild-$(OS)-$(DIST)
 	@echo "-------------------------------------------------------------------"
 	@echo "Building source package"
 	@echo "-------------------------------------------------------------------"
@@ -144,11 +141,9 @@ koji: $(BUILDDIR)/$(RPMSRC)
 clean::
 	rm -f $(BUILDDIR)/$(RPMSPEC)
 	rm -f $(BUILDDIR)/$(RPMSRC)
-	rm -f $(BUILDDIR)/$(PREBUILD)
-	rm -f $(BUILDDIR)/$(PREBUILD_OS)
-	rm -f $(BUILDDIR)/$(PREBUILD_OS_DIST)
 	rm -f $(BUILDDIR)/*.rpm
 	rm -f $(BUILDDIR)/build.log
 	rm -rf $(BUILDDIR)/$(RPMNAME)-$(VERSION)/
 
 .PRECIOUS:: $(BUILDDIR)/$(RPMNAME)-$(VERSION)/ $(BUILDDIR)/$(RPMSRC)
+.PHONY: prebuild prebuild-$(OS) prebuild-$(OS)-$(DIST)


### PR DESCRIPTION
Suppose I have a prebuild script and I'm debugging a build failure, so I have to start builds repeatedly and they fail somewhere along the way. In which case I have to manually remove `build/prebuild.sh` every time before I start a new build. Otherwise it would not be executed: the file exists (because the previous build failed), the prerequisite file `rpm/prebuild.sh` hasn't changed, so the corresponding rule is ignored by `make`. Which is a little annoying. On top of that I don't see any reasons to copy prebuild scripts from `rpm/` to `build/` before executing them.

Hence this PR converting prebuild rules to `.PHONY` targets, so we just execute prebuild scripts directly from the `rpm` directory unconditionally.