### PR TITLE
Exclude only top-level debian directory, not recursive

### DIFF
--- a/pack/tarball.mk
+++ b/pack/tarball.mk
@@ -36,7 +36,7 @@ $(BUILDDIR)/$(TARBALL): $(BUILDDIR)/ls-lR.txt $(BUILDDIR)/VERSION
 	tar \
 		--exclude=.git --exclude='.gitignore' --exclude='.gitmodules' \
 		$(TARBALL_EXTRA_ARGS) \
-		--exclude=FreeBSD --exclude=debian --exclude=rpm --exclude=rump --exclude=apk \
+		--exclude=FreeBSD --exclude=./debian --exclude=rpm --exclude=rump --exclude=apk \
 		--transform="s,$(BUILDDIR)/VERSION,VERSION,S" \
 		--transform="s,,$(PRODUCT)-$(VERSION)/,S" \
 		--owner=root --group=root \


### PR DESCRIPTION
GNU tar uses a glob pattern matching for --exclude. Thus, --exclude=debian excludes *all* directories named "debian" in the source tree, not only the top level one.

This PR just fixes this by excluding ./debian instead of "debian".