### PR TITLE
Prebuild changes and VAR_ env prefix

### DIFF
--- a/pack/deb.mk
+++ b/pack/deb.mk
@@ -53,10 +53,10 @@ prebuild: debian/$(PREBUILD)
 endif
 
 ifeq ($(wildcard debian/$(PREBUILD_OS)),)
-prebuild-$(OS):
+prebuild-$(OS): prebuild
 	# empty
 else
-prebuild-$(OS): debian/$(PREBUILD_OS)
+prebuild-$(OS): debian/$(PREBUILD_OS) prebuild
 	@echo "-------------------------------------------------------------------"
 	@echo "Running $(PREBUILD_OS) script"
 	@echo "-------------------------------------------------------------------"
@@ -65,10 +65,10 @@ prebuild-$(OS): debian/$(PREBUILD_OS)
 endif
 
 ifeq ($(wildcard debian/$(PREBUILD_OS_DIST)),)
-prebuild-$(OS)-$(DIST):
+prebuild-$(OS)-$(DIST): prebuild-$(OS)
 	# empty
 else
-prebuild-$(OS)-$(DIST): debian/$(PREBUILD_OS_DIST)
+prebuild-$(OS)-$(DIST): debian/$(PREBUILD_OS_DIST) prebuild-$(OS)
 	@echo "-------------------------------------------------------------------"
 	@echo "Running $(PREBUILD_OS_DIST) script"
 	@echo "-------------------------------------------------------------------"
@@ -111,8 +111,6 @@ prepare: $(BUILDDIR)/$(PRODUCT)-$(VERSION)/debian \
 #
 $(BUILDDIR)/$(DPKG_CHANGES): $(BUILDDIR)/$(PRODUCT)-$(VERSION)/debian \
                              $(BUILDDIR)/$(DPKG_ORIG_TARBALL) \
-                             prebuild \
-                             prebuild-$(OS) \
                              prebuild-$(OS)-$(DIST)
 	@echo "-------------------------------------------------------------------"
 	@echo "Installing dependencies"

--- a/pack/rpm.mk
+++ b/pack/rpm.mk
@@ -44,10 +44,10 @@ prebuild: rpm/$(PREBUILD)
 endif
 
 ifeq ($(wildcard rpm/$(PREBUILD_OS)),)
-prebuild-$(OS):
+prebuild-$(OS): prebuild
 	# empty
 else
-prebuild-$(OS): rpm/$(PREBUILD_OS)
+prebuild-$(OS): rpm/$(PREBUILD_OS) prebuild
 	@echo "-------------------------------------------------------------------"
 	@echo "Running $(PREBUILD_OS) script"
 	@echo "-------------------------------------------------------------------"
@@ -56,10 +56,10 @@ prebuild-$(OS): rpm/$(PREBUILD_OS)
 endif
 
 ifeq ($(wildcard rpm/$(PREBUILD_OS_DIST)),)
-prebuild-$(OS)-$(DIST):
+prebuild-$(OS)-$(DIST): prebuild-$(OS)
 	# empty
 else
-prebuild-$(OS)-$(DIST): rpm/$(PREBUILD_OS_DIST)
+prebuild-$(OS)-$(DIST): rpm/$(PREBUILD_OS_DIST) prebuild-$(OS)
 	@echo "-------------------------------------------------------------------"
 	@echo "Running $(PREBUILD_OS_DIST) script"
 	@echo "-------------------------------------------------------------------"
@@ -96,8 +96,6 @@ $(BUILDDIR)/$(RPMSPEC): $(RPMSPECIN)
 #
 $(BUILDDIR)/$(RPMSRC): $(BUILDDIR)/$(TARBALL) \
                        $(BUILDDIR)/$(RPMSPEC) \
-                       prebuild \
-                       prebuild-$(OS) \
                        prebuild-$(OS)-$(DIST)
 	@echo "-------------------------------------------------------------------"
 	@echo "Copying extra source files"

--- a/packpack
+++ b/packpack
@@ -125,7 +125,7 @@ chmod a+x ${BUILDDIR}/userwrapper.sh
 #
 # Save defined configuration variables to ./env file
 #
-env | grep -E "^PRODUCT=|^VERSION=|^RELEASE=|^ABBREV=|^TARBALL_|^CHANGELOG_|^CCACHE_|^PACKAGECLOUD_|^SMPFLAGS=|^OS=|^DIST=" \
+env | grep -E "^PRODUCT=|^VERSION=|^RELEASE=|^ABBREV=|^TARBALL_|^CHANGELOG_|^CCACHE_|^PACKAGECLOUD_|^SMPFLAGS=|^OS=|^DIST=|^VAR_" \
     > ${BUILDDIR}/env
 
 #


### PR DESCRIPTION
* Run prebuild*.sh scripts sequentially instead of undefined parallel order.
* Add VAR_ env prefix to allow to pass arbitrary custom variables during
  build and use them in scripts (prebuild*.sh for instance).