### PR TITLE
Allow to pass env variables to docker

### DIFF
--- a/packpack
+++ b/packpack
@@ -127,6 +127,7 @@ chmod a+x ${BUILDDIR}/userwrapper.sh
 #
 env | grep -E "^PRODUCT=|^VERSION=|^RELEASE=|^ABBREV=|^TARBALL_|^CHANGELOG_|^CCACHE_|^PACKAGECLOUD_|^SMPFLAGS=|^OS=|^DIST=" \
     > ${BUILDDIR}/env
+env | grep -E "^PACKPASS_" | sed 's/^PACKPASS_//g' >> ${BUILDDIR}/env
 
 #
 # Setup cache directory


### PR DESCRIPTION
Variables which name starts with `PACKPASS_` would be exported
into a docker container without the prefix.

That allows to pass any variable from Travis to an application.

E.g. `PACKPASS_XYZ=SOME` is exported as `XYZ=SOME`.

Closes #100