### PR TITLE
Skip non-exist packagecloud repository

### DIFF
--- a/pack/rpm.mk
+++ b/pack/rpm.mk
@@ -27,6 +27,13 @@ PREBUILD_OS := prebuild-$(OS).sh
 PREBUILD_OS_DIST := prebuild-$(OS)-$(DIST).sh
 THEDATE := $(shell date +"%a %b %d %Y")
 
+ifneq (,$(PACKAGECLOUD_USER))
+ifneq (,$(PACKAGECLOUD_REPO))
+PACKAGECLOUD_BASE_URL=https://packagecloud.io/install/repositories/$(PACKAGECLOUD_USER)/$(PACKAGECLOUD_REPO)
+PACKAGECLOUD_CONFIG_URL=$(PACKAGECLOUD_BASE_URL)/config_file.repo?os=$(OS)&dist=$(DIST)&source=script
+PACKAGECLOUD_SCRIPT_URL=$(PACKAGECLOUD_BASE_URL)/script.rpm.sh
+endif
+endif
 
 #
 # Run prebuild scripts
@@ -120,8 +127,11 @@ package: $(BUILDDIR)/$(RPMSRC)
 	@echo "-------------------------------------------------------------------"
 	@echo "Installing dependencies"
 	@echo "-------------------------------------------------------------------"
-	if [ -n "$(PACKAGECLOUD_USER)" ] && [ -n "$(PACKAGECLOUD_REPO)" ]; then \
-		curl -s https://packagecloud.io/install/repositories/$(PACKAGECLOUD_USER)/$(PACKAGECLOUD_REPO)/script.rpm.sh | sudo bash; \
+	# Skip the repository enabling if variables do not set or the
+	# repository does not exist.
+	if [ -n "$(PACKAGECLOUD_CONFIG_URL)" ] && \
+			curl -sSf "$(PACKAGECLOUD_CONFIG_URL)" >/dev/null; then \
+		curl -sSf "$(PACKAGECLOUD_SCRIPT_URL)" | sudo bash; \
 	fi
 	sudo dnf builddep -y $< || sudo yum-builddep -y $<
 	@echo


### PR DESCRIPTION
It is necessary for packpack packaging using packpack itself. We have
the variables PACKAGECLOUD_USER and PACKAGECLOUD_REPO set in CI to use
in deploy, but packpack detects them during build and trying to enable
the corresponding repository. When the repository does not exist the
build fails.

So, to deploy a first package for a new distro version we need some
packages already being pushed to the repository (or pushed and then
deleted). It was very inconvenient to enable the new distro version
because of that.