### PR TITLE
Don't enable target repo when building packpack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,11 @@ script:
  - git submodule update --init --recursive
  - git fetch -a
  - git describe --long --always
- - ./packpack
+ # Omit enabling of the packagecloud repository during build, because:
+ # 1. We don't use it during build.
+ # 2. It does not exists before we push a first package, that
+ #    lead to errors during repository updating.
+ - PACKAGECLOUD_USER="" PACKAGECLOUD_REPO="" ./packpack
 
 deploy:
   # Deploy packages to PackageCloud


### PR DESCRIPTION
This is another way to fix build of a first package for a new Ubuntu
distro, see f2f4d2d9660c97d2cb344126d5769ee3218bb72c for the first
attempt (that was reverted then).