### PR TITLE
rpm: don't add --with backtrace for rpmbuild

### DIFF
--- a/pack/rpm.mk
+++ b/pack/rpm.mk
@@ -135,7 +135,7 @@ package: $(BUILDDIR)/$(RPMSRC)
 		--define '_srcrpmdir $(BUILDDIR)' \
 		--define '_builddir $(BUILDDIR)/usr/src/debug' \
 		--define '_smp_mflags $(SMPFLAGS)' \
-		--rebuild --with backtrace $< 2>&1 | tee $(BUILDDIR)/build.log
+		--rebuild $< 2>&1 | tee $(BUILDDIR)/build.log
 	mv -f $(BUILDDIR)/RPMS/*/*.rpm $(BUILDDIR)
 	rm -rf $(BUILDDIR)/RPMS/ $(BUILDDIR)/BUILDROOT $(BUILDDIR)/usr
 	@echo "------------------------------------------------------------------"


### PR DESCRIPTION
First, we don't set it for building of a source package (`rpmbuild
-bs`), so yum-builddep / dnf-builddep will not install a dependency if
it is under `%if %{with backtrace} <...> %endif` in an RPM spec and
backtrace is disabled by default (via `%bcond_with backtrace`).

Second, it is simply incorrect to set this flag unconditionally in such
general-purpose tool as packpack. It is work of an RPM spec of a package
to set meaningful default value for each configurable parameter.

This flaw was found during a work on enabling CentOS 8 packages in
tarantool: https://github.com/tarantool/tarantool/issues/4543