### PR TITLE
Pass CI name to RPM spec and DEB rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,13 @@ See [PackPack Repositories] for additional instructions.
 
 PackPack performs the following steps:
 
+- Checks if it runs in CI environment reading predefined variables from CI
+  and sets its appropriate name in 'CI' variable from the list:
+    'appveyor', 'circle', 'github', 'gitlab', 'travis'.
+  If CI is not detected 'CI' variable will be empty.
+  'CI' is passed to RPM spec as '\_ci' macro and as 'CI' environment
+  variable to DEB rules.
+
 - A Docker container is started using `packpack/packpack:$OS$DIST` image.
 
 - The source repository is mounted to the container as a read-only volume.

--- a/pack/deb.mk
+++ b/pack/deb.mk
@@ -129,6 +129,7 @@ $(BUILDDIR)/$(DPKG_CHANGES): $(BUILDDIR)/$(PRODUCT)-$(VERSION)/debian \
 	@echo "-------------------------------------------------------------------"
 	cd $(BUILDDIR)/$(PRODUCT)-$(VERSION) && \
 		debuild --preserve-envvar CCACHE_DIR --prepend-path=/usr/lib/ccache \
+		--preserve-envvar CI \
 		-Z$(TARBALL_COMPRESSOR) -uc -us $(SMPFLAGS)
 	rm -rf $(BUILDDIR)/$(PRODUCT)-$(VERSION)/
 	@echo "------------------------------------------------------------------"

--- a/pack/rpm.mk
+++ b/pack/rpm.mk
@@ -109,6 +109,7 @@ $(BUILDDIR)/$(RPMSRC): $(BUILDDIR)/$(TARBALL) \
 		--define '_sourcedir $(BUILDDIR)' \
 		--define '_specdir $(BUILDDIR)' \
 		--define '_srcrpmdir $(BUILDDIR)' \
+		--define '_ci $(CI)' \
 		--define '_builddir $(BUILDDIR)/usr/src/debug' \
 		-bs $(BUILDDIR)/$(RPMSPEC)
 prepare: $(BUILDDIR)/$(RPMSRC)
@@ -133,6 +134,7 @@ package: $(BUILDDIR)/$(RPMSRC)
 		--define '_sourcedir $(BUILDDIR)' \
 		--define '_specdir $(BUILDDIR)' \
 		--define '_srcrpmdir $(BUILDDIR)' \
+		--define '_ci $(CI)' \
 		--define '_builddir $(BUILDDIR)/usr/src/debug' \
 		--define '_smp_mflags $(SMPFLAGS)' \
 		--rebuild $< 2>&1 | tee $(BUILDDIR)/build.log

--- a/packpack
+++ b/packpack
@@ -18,6 +18,25 @@ DOCKER_REPO=${DOCKER_REPO:-packpack/packpack}
 # Extra parameters for docker run.
 PACKPACK_EXTRA_DOCKER_RUN_PARAMS="${PACKPACK_EXTRA_DOCKER_RUN_PARAMS:-}"
 
+# Set CI variable to CI provider name
+CI=""
+if [ "${APPVEYOR:-}" = "True" -o "${APPVEYOR:-}" = "true" ]; then
+    # https://www.appveyor.com/docs/environment-variables/
+    CI="appveyor"
+elif [ "${CIRCLECI:-}" = "true" ]; then
+    # https://circleci.com/docs/2.0/env-vars/
+    CI="circle"
+elif [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    # https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables
+    CI="github"
+elif [ "${GITLAB_CI:-}" = "true" ]; then
+    # https://docs.gitlab.com/ee/ci/variables/
+    CI="gitlab"
+elif [ "${TRAVIS:-}" = "true" ]; then
+    # https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
+    CI="travis"
+fi
+
 # Docker architecture
 if [ -z "${ARCH}" ]; then
     # Use uname -m instead of HOSTTYPE
@@ -160,6 +179,7 @@ docker run \
         -e XDG_CACHE_HOME=/cache \
         -e CCACHE_DIR=/cache/ccache \
         -e TMPDIR=/tmp \
+        -e CI=${CI} \
         --volume "${CACHE_DIR}:/cache" \
         ${DOCKER_REPO}:${DOCKER_IMAGE} \
         make -f /pack/Makefile -C /source BUILDDIR=/build -j "$@"


### PR DESCRIPTION
Passed CI name to RPM spec as '_ci' macro and as 'CI' environment variable
to DEB rules. CI name detecting from CI predefined variables, currently
'appveyor', 'circle', 'github', 'gitlab', 'travis' CI names can be set,
otherwise it will be empty.

Part of https://github.com/tarantool/tarantool/issues/4599