### PR TITLE
Implement build for SuSE

### DIFF
--- a/pack/Makefile
+++ b/pack/Makefile
@@ -14,6 +14,8 @@ else ifneq (,$(wildcard /etc/debian_version))
 include $(PACKDIR)/deb.mk
 else ifneq (,$(wildcard /etc/alpine-release))
 include $(PACKDIR)/apk.mk
+else ifneq (,$(shell grep "^ID=\"opensuse-leap\"" /etc/os-release))
+include $(PACKDIR)/rpm.mk
 else
 prepare:
 package: tarball

--- a/pack/rpm.mk
+++ b/pack/rpm.mk
@@ -18,8 +18,31 @@ else
 RPMNAME := $(shell rpmspec -P $(RPMSPECIN) | sed -n -e 's/Name:\([\ \t]*\)\(.*\)/\2/p')
 endif
 
-RPMDIST := $(shell rpm -E "%{dist}")
-PKGVERSION := $(VERSION)-$(RELEASE)$(RPMDIST)
+# Usual 'Release' RPM spec directive value is 1%{?dist}, where
+# where 1 is $(RELEASE) value and %{dist} is like .el8 or .fc31.
+RPMRELEASE := $(RELEASE)%{dist}
+
+# Open Build Service (openSUSE) does not follow the usual
+# approach: 'Release' is like lp152.1.1, where the first 1 is
+# $(RELEASE) value and the second 1 is the number of rebuilds.
+#
+# We follow OBS way for openSUSE, because there is no %{dist}
+# macro defined and there are no recommendations for packaging
+# without OBS.
+ifeq ($(shell rpm -E "%{is_opensuse}"),1)
+	ifeq ($(shell rpm -E "%{sle_version}"),150000)
+		RPMDIST := lp150
+	endif
+	ifeq ($(shell rpm -E "%{sle_version}"),150100)
+		RPMDIST := lp151
+	endif
+	ifeq ($(shell rpm -E "%{sle_version}"),150200)
+		RPMDIST := lp152
+	endif
+	RPMRELEASE := $(RPMDIST).$(RELEASE).1
+endif
+
+PKGVERSION := $(shell rpm -E "$(VERSION)-$(RPMRELEASE)")
 RPMSPEC := $(RPMNAME).spec
 RPMSRC := $(RPMNAME)-$(PKGVERSION).src.rpm
 PREBUILD := prebuild.sh
@@ -72,6 +95,14 @@ prebuild-$(OS)-$(DIST): rpm/$(PREBUILD_OS_DIST) prebuild-$(OS)
 	@echo
 endif
 
+prebuild_cleanup:
+	# To avoid of such errors with broken repositories on openSuSE:
+	#   Media source 'http://download.opensuse.org/distribution/leap/15.2/repo/oss/' does not contain the desired medium
+	# need to cleanup and refresh it before use
+	if [ "$$(rpm -E '%{is_opensuse}')" == "1" ] ; then \
+		sudo zypper clean ; \
+		sudo zypper refresh ; \
+	fi
 
 $(BUILDDIR)/$(RPMSPEC): $(RPMSPECIN)
 	@echo "-------------------------------------------------------------------"
@@ -80,7 +111,7 @@ $(BUILDDIR)/$(RPMSPEC): $(RPMSPECIN)
 	@cp $< $@.tmp
 	sed \
 		-e 's/Version:\([ ]*\).*/Version: $(VERSION)/' \
-		-e 's/Release:\([ ]*\).*/Release: $(RELEASE)%{dist}/' \
+		-e 's/Release:\([ ]*\).*/Release: $(RPMRELEASE)/' \
 		-e 's/Source0:\([ ]*\).*/Source0: $(TARBALL)/' \
 		-e 's/%setup.*/%setup -q -n $(PRODUCT)-$(VERSION)/' \
                 -re 's/(%autosetup.*)( -n \S*)(.*)/\1\3/' \
@@ -88,7 +119,7 @@ $(BUILDDIR)/$(RPMSPEC): $(RPMSPECIN)
                 -e '/%changelog/a\* $(THEDATE) $(CHANGELOG_NAME) <$(CHANGELOG_EMAIL)> - $(VERSION)-$(RELEASE)\n\- $(CHANGELOG_TEXT)\n' \
 		-i $@.tmp
 	grep -F "Version: $(VERSION)" $@.tmp && \
-		grep -F "Release: $(RELEASE)" $@.tmp && \
+		grep -F "Release: $(RPMRELEASE)" $@.tmp && \
 		grep -F "Source0: $(TARBALL)" $@.tmp && \
 		(grep -F "%setup -q -n $(PRODUCT)-$(VERSION)" $@.tmp || \
 		grep -F "%autosetup" $@.tmp) || \
@@ -101,6 +132,7 @@ $(BUILDDIR)/$(RPMSPEC): $(RPMSPECIN)
 #
 $(BUILDDIR)/$(RPMSRC): $(BUILDDIR)/$(TARBALL) \
                        $(BUILDDIR)/$(RPMSPEC) \
+                       prebuild_cleanup \
                        prebuild-$(OS)-$(DIST)
 	@echo "-------------------------------------------------------------------"
 	@echo "Copying extra source files"
@@ -129,7 +161,8 @@ package: $(BUILDDIR)/$(RPMSRC)
 	if [ -n "$(PACKAGECLOUD_USER)" ] && [ -n "$(PACKAGECLOUD_REPO)" ]; then \
 		curl -s https://packagecloud.io/install/repositories/$(PACKAGECLOUD_USER)/$(PACKAGECLOUD_REPO)/script.rpm.sh | sudo bash; \
 	fi
-	sudo dnf builddep -y $< || sudo yum-builddep -y $<
+	sudo zypper --non-interactive source-install --build-deps-only --force-resolution --recommends $< || \
+		sudo dnf builddep -y $< || sudo yum-builddep -y $<
 	@echo
 	@echo "-------------------------------------------------------------------"
 	@echo "Building RPM packages"


### PR DESCRIPTION
Implemented ability to build openSuSE using pack/rpm.mk makefile.
openSuSE detects by checking of ID field equal to 'opensuse-leap'
within "/etc/os-release" file.
    
Usual 'Release' RPM spec directive:
```    
RPMRELEASE := $(RELEASE)%{dist}
```
where $(RELEASE) is '1' value and %{dist} is like '.el8' or '.fc31'.
    
Open Build Service (openSUSE) does not follow the usual approach - its
'Release' is like 'lp152.1.1', where:
   - 'lp152' value is the SuSE OS name: 'lp' - opensuse-leap w/ version;
   - the first '1' is $(RELEASE) value;
   - the second '1' is the number of rebuilds.
    
We follow OBS way for openSUSE, because there is no %{dist} macro
defined and there are no recommendations for packaging w/o OBS:
```
RPMRELEASE := $(RPMDIST).$(RELEASE).1
```
where $(RPMDIST) sets according to "%{sle_version}" macro, like when
%{sle_version} equal to '150200' then RPMDIST is 'lp152', check:
  https://en.opensuse.org/openSUSE:Packaging_for_Leap#RPM_Distro_Version_Macros
    
Added prebuild cleanup target rule to fix the issue with
broken repositories in zypper cache:
   Media source 'http://download.opensuse.org/distribution/leap/15.2/repo/oss/' does not contain the desired medium
It refreshes zypper cache.
    
Also SuSE uses build tool:
  "zypper source-install --build-deps-only --force-resolution --recommends"

Part of https://github.com/tarantool/tarantool/issues/4562

Co-authored-by: Alexander Turenko <alexander.turenko@tarantool.org>
