### PR TITLE
travis-ci: update testing OS matrix for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,25 +10,25 @@ env:
     matrix:
       - OS=el DIST=6
       - OS=el DIST=7
-      - OS=fedora DIST=26
-      - OS=fedora DIST=27
+      - OS=el DIST=8
       - OS=fedora DIST=28
+      - OS=fedora DIST=29
+      - OS=fedora DIST=30
+      - OS=fedora DIST=31
       - OS=ubuntu DIST=trusty
       - OS=ubuntu DIST=xenial
-      - OS=ubuntu DIST=artful
       - OS=ubuntu DIST=bionic
-      - OS=ubuntu DIST=cosmic
-      - OS=debian DIST=wheezy
+      - OS=ubuntu DIST=eoan
       - OS=debian DIST=jessie
       - OS=debian DIST=stretch
+      - OS=debian DIST=buster
       - OS=ubuntu DIST=trusty ARCH=i386
       - OS=ubuntu DIST=xenial ARCH=i386
-      - OS=ubuntu DIST=artful ARCH=i386
       - OS=ubuntu DIST=bionic ARCH=i386
-      - OS=ubuntu DIST=cosmic ARCH=i386
-      - OS=debian DIST=wheezy ARCH=i386
+      - OS=ubuntu DIST=eoan ARCH=i386
       - OS=debian DIST=jessie ARCH=i386
       - OS=debian DIST=stretch ARCH=i386
+      - OS=debian DIST=buster ARCH=i386
 
 script:
  - git submodule update --init --recursive


### PR DESCRIPTION
Updated testing OS matrix for Travis-CI:

removed due to EOL:
- Fedora 26/27
- Ubuntu 17.10/18.10
- Debian 7

added new OS to be supported:
- CentOS 8
- Fedora 29-31
- Ubuntu 19.10
- Debian 10