### PR TITLE
Allow to preserve certain environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ see an example in [Tarantool GitHub](https://github.com/tarantool/tarantool) rep
    used to bump version in changelog files.
 * `DOCKER_REPO` - a Docker repository to use (default is `packpack/packpack`).
 * `CCACHE*` - Config variables for ccache, such as CCACHE_DISABLE
+* `PRESERVE_ENVVARS` - a comma separated list of environment variables to
+  preserve.
 
 See the full list of available options and detailed configuration guide in
 [pack/config.mk](pack/config.mk) configuration file.

--- a/pack/config.mk
+++ b/pack/config.mk
@@ -84,3 +84,8 @@ TARBALL_COMPRESSOR ?= xz
 # Specifies the number of GNU make jobs (commands) to run simultaneously.
 #
 SMPFLAGS ?= -j$(shell nproc)
+
+#
+# A comma separated list of environment variables to preserve.
+#
+PRESERVE_ENVVARS ?=

--- a/pack/deb.mk
+++ b/pack/deb.mk
@@ -37,6 +37,15 @@ PREBUILD_OS_DIST := prebuild-$(OS)-$(DIST).sh
 # gh-7: Ubuntu/Debian should export DEBIAN_FRONTEND=noninteractive
 export DEBIAN_FRONTEND=noninteractive
 
+# Pass certain set of environment variables to the debuild's
+# environment.
+ifneq ($(PRESERVE_ENVVARS),)
+comma := ,
+opt := --preserve-envvar
+DEBUILD_PRESERVE_ENVVARS_OPTS := \
+	$(opt) $(subst $(comma), $(opt) ,$(PRESERVE_ENVVARS))
+endif
+
 #
 # Run prebuild scripts
 #
@@ -130,6 +139,7 @@ $(BUILDDIR)/$(DPKG_CHANGES): $(BUILDDIR)/$(PRODUCT)-$(VERSION)/debian \
 	cd $(BUILDDIR)/$(PRODUCT)-$(VERSION) && \
 		debuild --preserve-envvar CCACHE_DIR --prepend-path=/usr/lib/ccache \
 		--preserve-envvar CI \
+		$(DEBUILD_PRESERVE_ENVVARS_OPTS) \
 		-Z$(TARBALL_COMPRESSOR) -uc -us $(SMPFLAGS)
 	rm -rf $(BUILDDIR)/$(PRODUCT)-$(VERSION)/
 	@echo "------------------------------------------------------------------"

--- a/packpack
+++ b/packpack
@@ -162,6 +162,16 @@ env | grep "^VAR_" >> ${BUILDDIR}/env
 echo "CI=${CI}" >> ${BUILDDIR}/env
 
 #
+# Preserve environment variables as requested by a user.
+#
+if [ -n "${PRESERVE_ENVVARS:-}" ]; then
+    echo "PRESERVE_ENVVARS=${PRESERVE_ENVVARS}" >> ${BUILDDIR}/env
+    (IFS=,; for envvar in ${PRESERVE_ENVVARS}; do
+        env | grep "^${envvar}=" >> "${BUILDDIR}/env"
+    done)
+fi
+
+#
 # Setup cache directory
 #
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/packpack"

--- a/packpack
+++ b/packpack
@@ -147,8 +147,19 @@ chmod a+x ${BUILDDIR}/userwrapper.sh
 #
 # Save defined configuration variables to ./env file
 #
-env | grep -E "^PRODUCT=|^VERSION=|^RELEASE=|^ABBREV=|^TARBALL_|^CHANGELOG_|^CCACHE_|^PACKAGECLOUD_|^SMPFLAGS=|^OS=|^DIST=|^VAR_" \
-    > ${BUILDDIR}/env
+env | grep -E "^PRODUCT=|^VERSION=|^RELEASE=|^ABBREV=" > ${BUILDDIR}/env
+env | grep -E "^TARBALL_|^CHANGELOG_|^CCACHE_|^PACKAGECLOUD_" >> ${BUILDDIR}/env
+env | grep -E "^SMPFLAGS=|^OS=|^DIST=" >> ${BUILDDIR}/env
+
+#
+# Pass variables with 'VAR_' prefix.
+#
+env | grep "^VAR_" >> ${BUILDDIR}/env
+
+#
+# Pass continuous interation service name.
+#
+echo "CI=${CI}" >> ${BUILDDIR}/env
 
 #
 # Setup cache directory
@@ -179,7 +190,6 @@ docker run \
         -e XDG_CACHE_HOME=/cache \
         -e CCACHE_DIR=/cache/ccache \
         -e TMPDIR=/tmp \
-        -e CI=${CI} \
         --volume "${CACHE_DIR}:/cache" \
         ${DOCKER_REPO}:${DOCKER_IMAGE} \
         make -f /pack/Makefile -C /source BUILDDIR=/build -j "$@"


### PR DESCRIPTION
The idea is to list variables, which should be preserved from a parent
environment and pass them as for prebuild*.sh scripts as well as to the 
rpmbuild / debuild environment.

There were two attempts to solve the problem: `VAR_` prefix (#95,
pushed) and `PACKPASS_` prefix (#101, not pushed). Why I decided to
implement another one? We have a testing tool, which is tuneable using
environment variables. We have different jobs in CI, which invokes the 
tool. Some CI jobs use this tool directly, but some run packpack, which
calls it under rpmbuild or debuild. My wish it to set an environment
variable once (in CI settings) and use it everywhere: whether packpack
is used or not. I don't want to hack CI scripts or specs to pass the 
variables to the tool.

rpmbuild inherits a parent environment (maybe except certain variables),
so it does not require any changes aside passing a variable to the 
docker's environment.

debuild runs build scripts in a clean environment (that is nice) and so
requires to explicitly list all variables to preserve.

We can either set DEBUILD_PRESERVE_ENVVARS configuration variable
(`~/.devscripts`) or pass a bunch of --preserve-envvar command line
options. I choose the second way in order to show the variables in the 
build log.

The problem comes from [1].

Also made tiny preliminary refactoring of passing environment variables to the 
docker container. This is not strictly necessary, but makes the code easier to 
understand and fit lines to 80 symbols.

[1]: https://github.com/tarantool/test-run/issues/258

Fixes #100 
Supersedes #101