### PR TITLE
Clean dnf cache to avoid of hanged connections

### DIFF
--- a/pack/rpm.mk
+++ b/pack/rpm.mk
@@ -104,18 +104,18 @@ prebuild_cleanup:
 	#   236   rt_sigaction(SIGPIPE, NULL,  <unfinished ...>
 	#   237   <... connect resumed>)            = -1 ENETUNREACH (Network is unreachable)
 	# To avoid of it DNF cache should be cleaned before initial use:
-	if [ -f /etc/os-release ] ; then \
-		. /etc/os-release ; \
-		if [ "$$ID" == "fedora" -o "$$ID" == "centos" ] ; then \
-			echo "Cleaning up DNF cache" ; \
-			sudo dnf clean all ; \
-			sudo rm -rf /var/cache/dnf ; \
-			echo "Remove disabled 'failovermethod' since Fedora 29" ; \
-			sudo sed -i '/^failovermethod=/d' /etc/yum.repos.d/*.repo ; \
-			echo "Update packages" ; \
-			sudo dnf update -v -y ||: ; \
-		fi ; \
-	fi
+	#if [ -f /etc/os-release ] ; then \
+	#	. /etc/os-release ; \
+	#	if [ "$$ID" == "fedora" -o "$$ID" == "centos" ] ; then \
+	#		echo "Cleaning up DNF cache" ; \
+	#		sudo dnf clean all ; \
+	#		sudo rm -rf /var/cache/dnf ; \
+	#		echo "Remove disabled 'failovermethod' since Fedora 29" ; \
+	#		sudo sed -i '/^failovermethod=/d' /etc/yum.repos.d/*.repo ; \
+	#		echo "Update packages" ; \
+	#		sudo dnf update -v -y ||: ; \
+	#	fi ; \
+	#fi
 	# To avoid of such errors with broken repositories on openSuSE:
 	#   Media source 'http://download.opensuse.org/distribution/leap/15.2/repo/oss/' does not contain the desired medium
 	# need to cleanup and refresh it before use

--- a/packpack
+++ b/packpack
@@ -13,7 +13,7 @@ SOURCEDIR=${SOURCEDIR:-$PWD}
 BUILDDIR=${BUILDDIR:-${SOURCEDIR}/build}
 
 # Docker repository to use
-DOCKER_REPO=${DOCKER_REPO:-packpack/packpack}
+DOCKER_REPO=${DOCKER_REPO:-avtikhon/packpack}
 
 # Extra parameters for docker run.
 PACKPACK_EXTRA_DOCKER_RUN_PARAMS="${PACKPACK_EXTRA_DOCKER_RUN_PARAMS:-}"
@@ -187,7 +187,7 @@ chcon -Rt svirt_sandbox_file_t ${PACKDIR} ${SOURCEDIR} ${BUILDDIR} \
 # Start Docker
 #
 set -ex
-docker pull ${DOCKER_REPO}:${DOCKER_IMAGE}
+docker pull ${DOCKER_REPO}:${DOCKER_IMAGE}-dnfclean
 docker run \
         ${PACKPACK_EXTRA_DOCKER_RUN_PARAMS} \
         --volume "${PACKDIR}:/pack:ro" \
@@ -201,7 +201,7 @@ docker run \
         -e CCACHE_DIR=/cache/ccache \
         -e TMPDIR=/tmp \
         --volume "${CACHE_DIR}:/cache" \
-        ${DOCKER_REPO}:${DOCKER_IMAGE} \
+        ${DOCKER_REPO}:${DOCKER_IMAGE}-dnfclean \
         make -f /pack/Makefile -C /source BUILDDIR=/build -j "$@"
 retcode=$?
 rm -f ${BUILDDIR}/userwrapper.sh ${BUILDDIR}/env


### PR DESCRIPTION
Found that on old OS with old metadata in cache a lot of connections
hangs on the first packages update. On second packages update command
fails with errors because of hanged connections, like [1]:
```
  237   connect(11, {sa_family=AF_INET6, sin6_port=htons(443), sin6_flowinfo=htonl(0), inet_pton(AF_INET6, "2605:bc80:3010:600:dead:beef:cafe:fed9", &sin6_addr), sin6_scope_id=0}, 28 <unfinished ...>
  236   rt_sigaction(SIGPIPE, NULL,  <unfinished ...>
  237   <... connect resumed>)            = -1 ENETUNREACH (Network is unreachable)
```
To avoid of it DNF cache should be cleaned before initial use. Also
packages should be updated. Repositories configurations should be
cleaned from depricated options.

Closes tarantool/tarantool-qa#60
    
[1]: https://github.com/tarantool/tarantool-qa/issues/60#issuecomment-789596820