### PR TITLE
Support versions with alpha|beta|rc postfixes

### DIFF
--- a/pack/config.mk
+++ b/pack/config.mk
@@ -42,7 +42,12 @@ DESCRIBE := $(shell git describe --long --always)
 # Sic: please follow Semantic Versioning (http://semver.org),
 # Debian policies and Fedora guidelines then planning your releases.
 #
-VERSION ?= $(shell echo $(DESCRIBE) | sed -n 's/^\([0-9\.]*\)-\([0-9]*\)-\([a-z0-9]*\)/\1.\2/p')
+VERSION ?= $(shell echo $(DESCRIBE) | \
+sed -n 's/^\([0-9\.]*\)-\(alpha\|beta\|rc\)\([0-9]*\)-\([0-9]*\)-\([a-z0-9]*\)/\1-\2\3/p')
+ifeq ($(VERSION),)
+VERSION ?= $(shell echo $(DESCRIBE) | \
+sed -n 's/^\([0-9\.]*\)-\([0-9]*\)-\([a-z0-9]*\)/\1.\2/p')
+endif
 ifeq ($(VERSION),) # Fallback
 VERSION := 0.0.1
 endif
@@ -64,7 +69,7 @@ RELEASE ?= 1
 #   paradox.  The logic suggests to use 12 hexdigits for the Linux
 #   kernel, and 9 to 10 for Git itself.
 #
-ABBREV ?= $(shell echo $(DESCRIBE) | sed -n 's/^\([0-9\.]*\)-\([0-9]*\)-\([a-z0-9]*\)/\3/p')
+ABBREV ?= $(shell echo $(DESCRIBE) | grep -Eo "g[0-9a-z]*$")
 
 # Name, email and text for changelog entry
 CHANGELOG_NAME ?= PackPack

--- a/pack/tarball.mk
+++ b/pack/tarball.mk
@@ -3,7 +3,8 @@
 #
 
 ##
-TARBALL ?= $(PRODUCT)-$(VERSION).tar.$(TARBALL_COMPRESSOR)
+TARBALL_VERSION = $(shell echo $(VERSION) | sed 's@-\(alpha\|beta\|rc\)@~\1@')
+TARBALL ?= $(PRODUCT)-$(TARBALL_VERSION).tar.$(TARBALL_COMPRESSOR)
 
 #
 # Generate VERSION file
@@ -38,7 +39,7 @@ $(BUILDDIR)/$(TARBALL): $(BUILDDIR)/ls-lR.txt $(BUILDDIR)/VERSION
 		$(TARBALL_EXTRA_ARGS) \
 		--exclude=FreeBSD --exclude=debian --exclude=rpm --exclude=rump --exclude=apk \
 		--transform="s,$(BUILDDIR)/VERSION,VERSION,S" \
-		--transform="s,,$(PRODUCT)-$(VERSION)/,S" \
+		--transform="s,,$(PRODUCT)-$(TARBALL_VERSION)/,S" \
 		--owner=root --group=root \
 		-T $< --show-transformed \
 		-caPf $@ $(BUILDDIR)/VERSION $(TARBALL_EXTRA_FILES)
@@ -54,6 +55,6 @@ tarball: $(BUILDDIR)/$(TARBALL)
 clean::
 	rm -f $(BUILDDIR)/$(TARBALL)
 
-.PRECIOUS:: $(BUILDDIR)/$(TARBALL) $(BUILDDIR)/$(PRODUCT)-$(VERSION)/
+.PRECIOUS:: $(BUILDDIR)/$(TARBALL) $(BUILDDIR)/$(PRODUCT)-$(TARBALL_VERSION)/
 .INTERMEDIATE:: $(BUILDDIR)/ls-lR.txt $(BUILDDIR)/VERSION
 .PHONY: clean


### PR DESCRIPTION
Versioning schemas with alpha|beta|rc postfixes should use tilde as a separator, because, otherwise, 1.2.3-alphaN is a newer version than 1.2.3.
To avoid this comparison problem, have to use 1.2.3~alphaN instead.

Needs for: tarantool/tarantool#6184