### PR TITLE
deb: include epoch from debian/control

### DIFF
--- a/pack/deb.mk
+++ b/pack/deb.mk
@@ -3,6 +3,7 @@
 #
 
 DEB_VERSION:=$(VERSION)
+DEB_EPOCH:=$(shell grep '^[\ \t]*Version:' debian/control | sed -n 's/^[\ \t]*Version:[\ \t]*\([0-9]\+:\).*$$/\1/p')
 ifneq ($(shell dpkg-parsechangelog|grep ^Version|grep -E "g[abcdef0-9]{7,16}\-[0-9]+"),)
 ifneq ($(ABBREV),)
 # Add git abbreviation to follow the convention of official Debian packages
@@ -106,7 +107,7 @@ endif
 	# Bump version in debian/changelog
 	cd $(BUILDDIR)/$(PRODUCT)-$(VERSION) && \
 		NAME="$(CHANGELOG_NAME)" DEBEMAIL=$(CHANGELOG_EMAIL) \
-		dch -b -v "$(DEB_VERSION)-$(RELEASE)" "$(CHANGELOG_TEXT)"
+		dch -b -v "$(DEB_EPOCH)$(DEB_VERSION)-$(RELEASE)" "$(CHANGELOG_TEXT)"
 
 $(BUILDDIR)/$(DPKG_ORIG_TARBALL): $(BUILDDIR)/$(TARBALL)
 	# Create a symlink for orig.tar.gz


### PR DESCRIPTION
Debian package version supports epoch [1] value. Epochs can help when
the upstream version numbering scheme changes.

This patch introduces adding epoch automatically from debian/control
file. `DEB_EPOCH` variable is used for storing value of epoch.

- [1] https://www.debian.org/doc/debian-policy/ch-controlfields.html#version

Closes #79