### PR TITLE
Fix nopassword sudo on CentOS 7 in docker 20.10.18

### DIFF
--- a/packpack
+++ b/packpack
@@ -136,6 +136,7 @@ else
         echo "usermod -a -G sudo $USER 2>/dev/null || :";
         echo "usermod -a -G wheel $USER 2>/dev/null || :";
         echo "usermod -a -G adm $USER 2>/dev/null || :";
+        printf 'printf "%s\\tALL=(ALL)\\tNOPASSWD: ALL\\n" >> /etc/sudoers\n' $USER
         echo "export HOME=/home/$USER" ;
         echo "exec chroot --userspec=$USER / \$@";
     ) > ${BUILDDIR}/userwrapper.sh


### PR DESCRIPTION
## How the problem appears

> sudo: timed out reading password

## Known prerequisites to reproduce the problem

* Ubuntu host system.
* Docker 20.10.18 or newer.
* A build against CentOS 7 (`OS=el DIST=7 /path/to/packpack`).

I'm not sure, but maybe we also need an `rpm/prebuild.sh` script that invokes `sudo`.

## Summary of investigation

In given circumstances the following sudoers line doesn't work as expected:

```
%wheel	ALL=(ALL)	NOPASSWD: ALL
```

## Brief explanation of the fix

Add current user into sudoers file:

```
<..user..>	ALL=(ALL)	NOPASSWD: ALL
```

`printf` is used instead of `echo` for portability between `bash` and `dash`.

## Details

A more detailed investigation of the problem and an explanation of the fix could be found in the linked issue.

Fixes #145