### PR TITLE
Fix Alpine package release number

### DIFF
--- a/pack/config.mk
+++ b/pack/config.mk
@@ -50,9 +50,15 @@ endif
 # The number of times this version of the software has been packaged.
 # This feature is not implemented yet, therefore value is always set to 1.
 #
-# Sic: Both Debian policies and Fedora guidelines discourage 0 value.
+# Sic: Both Debian policies and Fedora guidelines discourage 0 value, however
+# the Alpine documentation states that the release number should start at 0.
+# See for details: https://wiki.alpinelinux.org/wiki/APKBUILD_Reference#pkgrel
 #
+ifeq ($(OS),alpine)
+RELEASE ?= 0
+else
 RELEASE ?= 1
+endif
 
 #
 # git abbreviation with 'g' prefix, 7+ hexadecimal digits


### PR DESCRIPTION
The Alpine documentation states that the package release number should start at 0 [1], not at 1. This patch fixes that.

[1] https://wiki.alpinelinux.org/wiki/APKBUILD_Reference#pkgrel