### PR TITLE
 deb: add parameter to disable abbrev suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ see an example in [Tarantool GitHub](https://github.com/tarantool/tarantool) rep
    packaged (default is 1).
 * `ABBREV` - abbreviation of build metadata (default is git hash, extracted
    from `git describe`).
+* `DISABLE_ABBREV` - if set `OFF` disable abbreviation for deb packages
 *  `TARBALL_COMPRESSOR` - a compression algorithm to use, e.g. gz, bz2, xz
    (default is xz).
 * `CHANGELOG_NAME`, `CHANGELOG_EMAIL`, `CHANGELOG_TEXT` - information

--- a/pack/deb.mk
+++ b/pack/deb.mk
@@ -10,6 +10,10 @@ ifneq ($(ABBREV),)
 DEB_VERSION := $(VERSION).$(ABBREV)
 $(info Added git hash to Debian package version: $(VERSION) => $(DEB_VERSION))
 endif
+# Disable ABBREV for Deb packages
+ifeq ($(DISABLE_ABBREV), ON)
+DEB_VERSION := $(VERSION)
+endif
 endif
 
 DPKG_ARCH:=$(shell dpkg --print-architecture)

--- a/packpack
+++ b/packpack
@@ -154,7 +154,7 @@ chmod a+x ${BUILDDIR}/userwrapper.sh
 #
 # Save defined configuration variables to ./env file
 #
-env | grep -E "^PRODUCT=|^VERSION=|^RELEASE=|^ABBREV=" > ${BUILDDIR}/env
+env | grep -E "^PRODUCT=|^VERSION=|^RELEASE=|^ABBREV=|^DISABLE_ABBREV=" > ${BUILDDIR}/env
 env | grep -E "^TARBALL_|^CHANGELOG_|^CCACHE_|^PACKAGECLOUD_" >> ${BUILDDIR}/env
 env | grep -E "^SMPFLAGS=|^OS=|^DIST=" >> ${BUILDDIR}/env
 


### PR DESCRIPTION
ABBREV is used to add a suffix to the package name. Usually it could be set to git hash or count of commits. But in some cases it is not needed. This patch adds a parameter to disable abbrev suffixes.  Example: `DISABLE_ABBREV=ON`.
