### PR TITLE
Support using of local docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ see an example in [Tarantool GitHub](https://github.com/tarantool/tarantool) rep
 * `CHANGELOG_NAME`, `CHANGELOG_EMAIL`, `CHANGELOG_TEXT` - information
    used to bump version in changelog files.
 * `DOCKER_REPO` - a Docker repository to use (default is `packpack/packpack`).
+* `USE_LOCAL_IMAGE` - if not empty try to use local docker image first (by default docker image is pulled from the `DOCKER_REPO`).
 * `CCACHE*` - Config variables for ccache, such as CCACHE_DISABLE
 * `PRESERVE_ENVVARS` - a comma separated list of environment variables to
   preserve.

--- a/packpack
+++ b/packpack
@@ -88,6 +88,7 @@ usage() {
     echo " * DIST - the version of distribution, e.g. xenial or 24 (${DIST})"
     echo " * BUILDDIR - directory used for out-of-source build (${BUILDDIR})"
     echo " * DOCKER_REPO - Docker repository to use (${DOCKER_REPO})"
+    echo " * USE_LOCAL_IMAGE - if not empty try to use local docker image first"
     echo ""
     echo "See also ${PACKDIR}/config.mk"
     echo ""
@@ -201,7 +202,9 @@ chcon -Rt svirt_sandbox_file_t ${PACKDIR} ${SOURCEDIR} ${BUILDDIR} \
 # Start Docker
 #
 set -ex
-docker pull ${DOCKER_REPO}:${DOCKER_IMAGE}
+if [ -z "$USE_LOCAL_IMAGE" ]; then
+    docker pull ${DOCKER_REPO}:${DOCKER_IMAGE}
+fi
 docker run \
         ${PACKPACK_EXTRA_DOCKER_RUN_PARAMS} \
         --volume "${PACKDIR}:/pack:ro" \


### PR DESCRIPTION
USE_LOCAL_IMAGE environment is introduced to be used to suppress explicit pulling of the docker image. If USE_LOCAL_IMAGE is not empty `docker pull` command is skipped.
`docker run` pull the image automatically only if it doesn't exist locally, so by specifying non-empty USE_LOCAL_IMAGE one is able to run packpack in a local docker image.
    
Ex: OS=mosos DIST=15.4 USE_LOCAL_IMAGE=1 ./packpack

Closes #154